### PR TITLE
Default files to save simulation

### DIFF
--- a/abeeda/main.cpp
+++ b/abeeda/main.cpp
@@ -92,7 +92,11 @@ int main(int argc, char *argv[])
     string LODFileName = "", swarmGenomeFileName = "", predatorGenomeFileName = "", inputGenomeFileName = "";
     string swarmDotFileName = "", predatorDotFileName = "", logicTableFileName = "";
     int displayDirectoryArgvIndex = 0;
-    
+    // Default files to save simulation
+    swarmGenomeFileName = "../work/EndSwarm.genome";
+    predatorGenomeFileName = "../work/EndPredator.genome";
+    LODFileName = "../work/LOD.csv";	
+	
     // initial object setup
     swarmAgents.resize(populationSize);
     predatorAgents.resize(populationSize);


### PR DESCRIPTION
In case of simulation without the option to specify the swarmGenomeFileName and/or predatorGenomeFileName and/or LODFileName 
We specify the same directory of the default predator genome file